### PR TITLE
yandex_music: remove lyrics feature support

### DIFF
--- a/music_assistant/providers/yandex_music/__init__.py
+++ b/music_assistant/providers/yandex_music/__init__.py
@@ -36,7 +36,6 @@ SUPPORTED_FEATURES = {
     ProviderFeature.LIBRARY_ALBUMS_EDIT,
     ProviderFeature.LIBRARY_TRACKS_EDIT,
     ProviderFeature.BROWSE,
-    ProviderFeature.LYRICS,
 }
 
 

--- a/music_assistant/providers/yandex_music/api_client.py
+++ b/music_assistant/providers/yandex_music/api_client.py
@@ -195,34 +195,6 @@ class YandexMusicClient:
             LOGGER.error("Error fetching tracks: %s", err)
             return []
 
-    async def get_track_lyrics(self, track_id: str) -> tuple[str | None, str | None]:
-        """Get lyrics for a track (plain text and optional LRC).
-
-        Uses API GET /tracks/{id}/lyrics (same as web); fetches content via
-        TrackLyrics.fetch_lyrics_async() from the signed download URL.
-
-        :param track_id: Track ID.
-        :return: (lyrics_plain, lyrics_lrc) or (None, None) if not available.
-        """
-        client = self._ensure_connected()
-        lyrics_plain: str | None = None
-        lyrics_lrc: str | None = None
-        try:
-            lyrics_obj = await client.tracks_lyrics(track_id, format_="TEXT")
-            if lyrics_obj and hasattr(lyrics_obj, "fetch_lyrics_async"):
-                raw = await lyrics_obj.fetch_lyrics_async()
-                lyrics_plain = (raw.strip() if raw else None) or None
-        except Exception as err:  # NotFoundError, UnauthorizedError, etc.
-            LOGGER.debug("Lyrics for track %s: %s", track_id, err)
-        try:
-            lrc_obj = await client.tracks_lyrics(track_id, format_="LRC")
-            if lrc_obj and hasattr(lrc_obj, "fetch_lyrics_async"):
-                raw = await lrc_obj.fetch_lyrics_async()
-                lyrics_lrc = (raw.strip() if raw else None) or None
-        except Exception:  # noqa: S110
-            pass
-        return (lyrics_plain, lyrics_lrc)
-
     async def get_album(self, album_id: str) -> YandexAlbum | None:
         """Get a single album by ID.
 

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -199,18 +199,7 @@ class YandexMusicProvider(MusicProvider):
         yandex_track = await self.client.get_track(prov_track_id)
         if not yandex_track:
             raise MediaNotFoundError(f"Track {prov_track_id} not found")
-        track = parse_track(self, yandex_track)
-        lyrics_result = await self.client.get_track_lyrics(prov_track_id)
-        lyrics_plain, lyrics_lrc = (
-            lyrics_result
-            if isinstance(lyrics_result, tuple) and len(lyrics_result) == 2
-            else (None, None)
-        )
-        if lyrics_plain:
-            track.metadata.lyrics = lyrics_plain
-        if lyrics_lrc:
-            track.metadata.lrc_lyrics = lyrics_lrc
-        return track
+        return parse_track(self, yandex_track)
 
     @use_cache(3600 * 24 * 30)
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:

--- a/tests/providers/yandex_music/test_integration.py
+++ b/tests/providers/yandex_music/test_integration.py
@@ -132,7 +132,6 @@ async def yandex_music_provider(
         mock_client.get_artist_tracks = mock.AsyncMock(return_value=[track])
         mock_client.get_playlist = mock.AsyncMock(return_value=playlist)
         mock_client.get_track_download_info = mock.AsyncMock(return_value=[download_info])
-        mock_client.get_track_lyrics = mock.AsyncMock(return_value=(None, None))
 
         async with wait_for_sync_completion(mass):
             config = await mass.config.save_provider_config(
@@ -207,7 +206,6 @@ async def yandex_music_provider_lossless(
         # get-file-info lossless is tried first; mock returns None so we use download_info path
         mock_client.get_track_file_info_lossless = mock.AsyncMock(return_value=None)
         mock_client.get_track_download_info = mock.AsyncMock(return_value=download_infos)
-        mock_client.get_track_lyrics = mock.AsyncMock(return_value=(None, None))
 
         async with wait_for_sync_completion(mass):
             config = await mass.config.save_provider_config(


### PR DESCRIPTION
## Summary
- Remove lyrics feature from Yandex Music provider
- Delete `get_track_lyrics()` API method
- Remove `ProviderFeature.LYRICS` from supported features
- Clean up associated test mocks

## Test plan
- [x] Run `pytest tests/providers/yandex_music/` - all 37 tests pass
- [x] Verify syntax with AST parser
- [x] Ruff linter/formatter pass

🤖 Generated with [Claude Code](https://claude.ai/code)