### PR TITLE
fix(yandex_music, vk_music): fix playlist tracks not loading and suppress noisy logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ venv/
 .idea
 .coverage
 uv.lock
+logs/

--- a/music_assistant/providers/vk_music/api_client.py
+++ b/music_assistant/providers/vk_music/api_client.py
@@ -15,6 +15,13 @@ from vkpymusic.vk_api import VkApiException
 
 from .constants import DEFAULT_LIMIT, DEFAULT_USER_AGENT
 
+# Prevent vkpymusic from writing log files into project logs/
+_vkpymusic_logger = logging.getLogger("vkpymusic")
+for _h in list(_vkpymusic_logger.handlers):
+    if isinstance(_h, logging.FileHandler):
+        _vkpymusic_logger.removeHandler(_h)
+        _h.close()
+
 # Error message for tokens without audio API access
 AUDIO_ACCESS_DENIED_MSG = (
     "VK Music token does not have audio API access. "

--- a/music_assistant/providers/vk_music/provider.py
+++ b/music_assistant/providers/vk_music/provider.py
@@ -58,13 +58,8 @@ class VKMusicProvider(MusicProvider):
 
         self._client = VKMusicClient(str(token))
         await self._client.connect()
-        # Prevent vkpymusic from writing its own log files into project logs/
-        vkpymusic_logger = logging.getLogger("vkpymusic")
-        for handler in list(vkpymusic_logger.handlers):
-            if isinstance(handler, logging.FileHandler):
-                vkpymusic_logger.removeHandler(handler)
-                handler.close()
-        vkpymusic_logger.setLevel(self.logger.level + 10)
+        # Suppress vkpymusic DEBUG logs (FileHandler already removed in api_client.py)
+        logging.getLogger("vkpymusic").setLevel(self.logger.level + 10)
         self.logger.info("Successfully connected to VK Music")
 
     async def unload(self, is_removed: bool = False) -> None:

--- a/music_assistant/providers/vk_music/provider.py
+++ b/music_assistant/providers/vk_music/provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import ContentType, MediaType, StreamType
@@ -57,6 +58,13 @@ class VKMusicProvider(MusicProvider):
 
         self._client = VKMusicClient(str(token))
         await self._client.connect()
+        # Prevent vkpymusic from writing its own log files into project logs/
+        vkpymusic_logger = logging.getLogger("vkpymusic")
+        for handler in list(vkpymusic_logger.handlers):
+            if isinstance(handler, logging.FileHandler):
+                vkpymusic_logger.removeHandler(handler)
+                handler.close()
+        vkpymusic_logger.setLevel(self.logger.level + 10)
         self.logger.info("Successfully connected to VK Music")
 
     async def unload(self, is_removed: bool = False) -> None:

--- a/music_assistant/providers/yandex_music/api_client.py
+++ b/music_assistant/providers/yandex_music/api_client.py
@@ -186,21 +186,22 @@ class YandexMusicClient:
 
         :param track_ids: List of track IDs.
         :return: List of track objects.
+        :raises ResourceTemporarilyUnavailable: On network errors after retry.
         """
         client = self._ensure_connected()
         try:
             result = await client.tracks(track_ids)
             return result or []
-        except (BadRequestError, NetworkError) as err:
-            err_str = str(err).lower()
-            if "timeout" in err_str or "timed out" in err_str:
-                LOGGER.warning("Fetching tracks timed out, retrying once: %s", err)
-                try:
-                    result = await client.tracks(track_ids)
-                    return result or []
-                except (BadRequestError, NetworkError) as retry_err:
-                    LOGGER.error("Error fetching tracks (retry failed): %s", retry_err)
-                    return []
+        except NetworkError as err:
+            # Retry once on network errors (timeout, disconnect, etc.)
+            LOGGER.warning("Network error fetching tracks, retrying once: %s", err)
+            try:
+                result = await client.tracks(track_ids)
+                return result or []
+            except NetworkError as retry_err:
+                LOGGER.error("Error fetching tracks (retry failed): %s", retry_err)
+                raise ResourceTemporarilyUnavailable("Failed to fetch tracks") from retry_err
+        except BadRequestError as err:
             LOGGER.error("Error fetching tracks: %s", err)
             return []
 

--- a/music_assistant/providers/yandex_music/api_client.py
+++ b/music_assistant/providers/yandex_music/api_client.py
@@ -192,6 +192,15 @@ class YandexMusicClient:
             result = await client.tracks(track_ids)
             return result or []
         except (BadRequestError, NetworkError) as err:
+            err_str = str(err).lower()
+            if "timeout" in err_str or "timed out" in err_str:
+                LOGGER.warning("Fetching tracks timed out, retrying once: %s", err)
+                try:
+                    result = await client.tracks(track_ids)
+                    return result or []
+                except (BadRequestError, NetworkError) as retry_err:
+                    LOGGER.error("Error fetching tracks (retry failed): %s", retry_err)
+                    return []
             LOGGER.error("Error fetching tracks: %s", err)
             return []
 

--- a/music_assistant/providers/yandex_music/api_client.py
+++ b/music_assistant/providers/yandex_music/api_client.py
@@ -301,6 +301,7 @@ class YandexMusicClient:
         :param user_id: User ID (owner of the playlist).
         :param playlist_id: Playlist ID (kind).
         :return: Playlist object or None if not found.
+        :raises ResourceTemporarilyUnavailable: On network errors.
         """
         client = self._ensure_connected()
         try:
@@ -308,7 +309,10 @@ class YandexMusicClient:
             if isinstance(result, list):
                 return result[0] if result else None
             return result
-        except (BadRequestError, NetworkError) as err:
+        except NetworkError as err:
+            LOGGER.warning("Network error fetching playlist %s/%s: %s", user_id, playlist_id, err)
+            raise ResourceTemporarilyUnavailable("Failed to fetch playlist") from err
+        except BadRequestError as err:
             LOGGER.error("Error fetching playlist %s/%s: %s", user_id, playlist_id, err)
             return None
 

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -11,6 +11,7 @@ from music_assistant_models.errors import (
     LoginFailed,
     MediaNotFoundError,
     ProviderUnavailableError,
+    ResourceTemporarilyUnavailable,
 )
 from music_assistant_models.media_items import (
     Album,
@@ -266,16 +267,22 @@ class YandexMusicProvider(MusicProvider):
 
         playlist = await self.client.get_playlist(owner_id, kind)
         if not playlist:
-            return []
+            raise MediaNotFoundError(f"Playlist {prov_playlist_id} not found")
 
         # API sometimes returns playlist without tracks on first load; fetch explicitly if needed
         tracks_list = list(playlist.tracks) if playlist.tracks else []
         if not tracks_list and (getattr(playlist, "track_count", 0) or 0) > 0:
             try:
-                tracks_list = await playlist.fetch_tracks_async()
-            except Exception as err:  # noqa: BLE001
+                fetched = await playlist.fetch_tracks_async()
+                tracks_list = list(fetched) if fetched else []
+            except Exception as err:
                 self.logger.debug("fetch_tracks_async failed: %s", err)
         if not tracks_list:
+            track_count = getattr(playlist, "track_count", 0) or 0
+            if track_count > 0:
+                raise ResourceTemporarilyUnavailable(
+                    "Playlist tracks temporarily unavailable; please retry"
+                )
             return []
 
         # Yandex returns TrackShort objects, we need to fetch full track info
@@ -294,6 +301,10 @@ class YandexMusicProvider(MusicProvider):
         for i in range(0, len(track_ids), batch_size):
             batch_ids = track_ids[i : i + batch_size]
             full_tracks.extend(await self.client.get_tracks(batch_ids))
+        if not full_tracks and track_ids:
+            raise ResourceTemporarilyUnavailable(
+                "Failed to load playlist tracks (timeout or error); please retry"
+            )
         tracks = []
         for track in full_tracks:
             try:

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -265,21 +265,35 @@ class YandexMusicProvider(MusicProvider):
             kind = prov_playlist_id
 
         playlist = await self.client.get_playlist(owner_id, kind)
-        if not playlist or not playlist.tracks:
+        if not playlist:
+            return []
+
+        # API sometimes returns playlist without tracks on first load; fetch explicitly if needed
+        tracks_list = list(playlist.tracks) if playlist.tracks else []
+        if not tracks_list and (getattr(playlist, "track_count", 0) or 0) > 0:
+            try:
+                tracks_list = await playlist.fetch_tracks_async()
+            except Exception as err:  # noqa: BLE001
+                self.logger.debug("fetch_tracks_async failed: %s", err)
+        if not tracks_list:
             return []
 
         # Yandex returns TrackShort objects, we need to fetch full track info
         track_ids = [
             str(track.track_id) if hasattr(track, "track_id") else str(track.id)
-            for track in playlist.tracks
+            for track in tracks_list
             if track
         ]
 
         if not track_ids:
             return []
 
-        # Fetch full track details
-        full_tracks = await self.client.get_tracks(track_ids)
+        # Fetch full track details in batches to avoid timeouts on large playlists
+        batch_size = 50
+        full_tracks = []
+        for i in range(0, len(track_ids), batch_size):
+            batch_ids = track_ids[i : i + batch_size]
+            full_tracks.extend(await self.client.get_tracks(batch_ids))
         tracks = []
         for track in full_tracks:
             try:

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -11,6 +11,7 @@ from music_assistant_models.errors import (
     LoginFailed,
     MediaNotFoundError,
     ProviderUnavailableError,
+    ResourceTemporarilyUnavailable,
 )
 from music_assistant_models.media_items import (
     Album,
@@ -257,6 +258,11 @@ class YandexMusicProvider(MusicProvider):
         :param page: Page number for pagination.
         :return: List of Track objects.
         """
+        # Yandex Music API returns all playlist tracks in one call (no server-side pagination)
+        if page > 0:
+            return []
+
+        self.logger.debug("get_playlist_tracks called: %s", prov_playlist_id)
         # Parse the playlist ID (format: owner_id:kind)
         if PLAYLIST_ID_SPLITTER in prov_playlist_id:
             owner_id, kind = prov_playlist_id.split(PLAYLIST_ID_SPLITTER, 1)
@@ -264,28 +270,72 @@ class YandexMusicProvider(MusicProvider):
             owner_id = str(self.client.user_id)
             kind = prov_playlist_id
 
+        self.logger.debug("Fetching playlist %s/%s from API...", owner_id, kind)
         playlist = await self.client.get_playlist(owner_id, kind)
-        if not playlist or not playlist.tracks:
+        if not playlist:
+            self.logger.debug("Playlist %s/%s not found", owner_id, kind)
+            return []
+
+        # API sometimes returns playlist without tracks; fetch them explicitly if needed
+        tracks_list = playlist.tracks or []
+        track_count = getattr(playlist, "track_count", None) or 0
+        self.logger.debug(
+            "Playlist %s/%s: track_count=%s, tracks_in_response=%s",
+            owner_id, kind, track_count, len(tracks_list),
+        )
+        if not tracks_list and track_count > 0:
+            self.logger.debug("No tracks in response, calling fetch_tracks_async...")
+            try:
+                tracks_list = await playlist.fetch_tracks_async()
+                self.logger.debug("fetch_tracks_async returned %s tracks", len(tracks_list or []))
+            except Exception as err:  # noqa: BLE001
+                self.logger.warning("fetch_tracks_async failed: %s", err)
+            if not tracks_list and track_count > 0:
+                self.logger.warning(
+                    "Playlist %s/%s: expected %s tracks but got none",
+                    owner_id, kind, track_count,
+                )
+                raise ResourceTemporarilyUnavailable(
+                    "Playlist tracks not available; try again later"
+                ) from None
+
+        if not tracks_list:
+            self.logger.debug("Playlist %s/%s has no tracks", owner_id, kind)
             return []
 
         # Yandex returns TrackShort objects, we need to fetch full track info
         track_ids = [
             str(track.track_id) if hasattr(track, "track_id") else str(track.id)
-            for track in playlist.tracks
+            for track in tracks_list
             if track
         ]
-
         if not track_ids:
             return []
 
-        # Fetch full track details
-        full_tracks = await self.client.get_tracks(track_ids)
+        self.logger.debug("Fetching full details for %s tracks...", len(track_ids))
+        # Fetch full track details in batches to avoid timeouts
+        batch_size = 50
+        full_tracks = []
+        for i in range(0, len(track_ids), batch_size):
+            batch = track_ids[i : i + batch_size]
+            self.logger.debug("Fetching batch %s-%s...", i, i + len(batch))
+            batch_result = await self.client.get_tracks(batch)
+            self.logger.debug("Batch returned %s tracks", len(batch_result or []))
+            full_tracks.extend(batch_result or [])
+
+        if track_ids and not full_tracks:
+            self.logger.warning("Got 0 full tracks for %s IDs", len(track_ids))
+            raise ResourceTemporarilyUnavailable(
+                "Failed to load track details; try again later"
+            ) from None
+
         tracks = []
         for track in full_tracks:
             try:
                 tracks.append(parse_track(self, track))
             except InvalidDataError as err:
                 self.logger.debug("Error parsing playlist track: %s", err)
+        self.logger.debug("Returning %s parsed tracks", len(tracks))
         return tracks
 
     @use_cache(3600 * 24 * 7)

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import MediaType
@@ -63,6 +64,8 @@ class YandexMusicProvider(MusicProvider):
 
         self._client = YandexMusicClient(str(token))
         await self._client.connect()
+        # Suppress yandex_music library DEBUG dumps (full API request/response JSON)
+        logging.getLogger("yandex_music").setLevel(self.logger.level + 10)
         self._streaming = YandexMusicStreamingManager(self)
         self.logger.info("Successfully connected to Yandex Music")
 

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -11,7 +11,6 @@ from music_assistant_models.errors import (
     LoginFailed,
     MediaNotFoundError,
     ProviderUnavailableError,
-    ResourceTemporarilyUnavailable,
 )
 from music_assistant_models.media_items import (
     Album,
@@ -266,45 +265,21 @@ class YandexMusicProvider(MusicProvider):
             kind = prov_playlist_id
 
         playlist = await self.client.get_playlist(owner_id, kind)
-        if not playlist:
-            raise MediaNotFoundError(f"Playlist {prov_playlist_id} not found")
-
-        # API sometimes returns playlist without tracks on first load; fetch explicitly if needed
-        tracks_list = list(playlist.tracks) if playlist.tracks else []
-        if not tracks_list and (getattr(playlist, "track_count", 0) or 0) > 0:
-            try:
-                fetched = await playlist.fetch_tracks_async()
-                tracks_list = list(fetched) if fetched else []
-            except Exception as err:
-                self.logger.debug("fetch_tracks_async failed: %s", err)
-        if not tracks_list:
-            track_count = getattr(playlist, "track_count", 0) or 0
-            if track_count > 0:
-                raise ResourceTemporarilyUnavailable(
-                    "Playlist tracks temporarily unavailable; please retry"
-                )
+        if not playlist or not playlist.tracks:
             return []
 
         # Yandex returns TrackShort objects, we need to fetch full track info
         track_ids = [
             str(track.track_id) if hasattr(track, "track_id") else str(track.id)
-            for track in tracks_list
+            for track in playlist.tracks
             if track
         ]
 
         if not track_ids:
             return []
 
-        # Fetch full track details in batches to avoid timeouts on large playlists
-        batch_size = 50
-        full_tracks = []
-        for i in range(0, len(track_ids), batch_size):
-            batch_ids = track_ids[i : i + batch_size]
-            full_tracks.extend(await self.client.get_tracks(batch_ids))
-        if not full_tracks and track_ids:
-            raise ResourceTemporarilyUnavailable(
-                "Failed to load playlist tracks (timeout or error); please retry"
-            )
+        # Fetch full track details
+        full_tracks = await self.client.get_tracks(track_ids)
         tracks = []
         for track in full_tracks:
             try:


### PR DESCRIPTION
## Summary

- **Fix Yandex Music playlist tracks not displaying in UI**: The controller's pagination loop never terminated because `get_playlist_tracks` returned the same tracks for every page. Now returns `[]` for `page > 0` since Yandex Music API returns all tracks in a single call.
- **Add `fetch_tracks_async()` fallback**: When the API returns playlist metadata without tracks, explicitly fetch them via `playlist.fetch_tracks_async()`.
- **Prevent caching of empty results**: Raise `ResourceTemporarilyUnavailable` instead of returning `[]` when tracks are expected but unavailable, so the cache doesn't store stale empty responses.
- **Batch track detail fetching**: Fetch full track details in batches of 50 to reduce timeout risk on large playlists.
- **Suppress noisy library logs**: Set `yandex_music` logger level above provider level to avoid huge JSON dumps in DEBUG mode.
- **Prevent vkpymusic log file creation**: Remove `FileHandler` from `vkpymusic` logger to stop it from writing files into `logs/`.

## Test plan

- [x] Open a Yandex Music playlist in the UI — tracks load correctly on first open
- [x] Reload the page — tracks load from cache without extra API calls
- [x] Verify no `vkpymusic_*.log` files appear in `logs/`
- [x] Verify DEBUG logs don't contain raw Yandex API JSON dumps


Made with [Cursor](https://cursor.com)