### PR TITLE
fix(vk_music): fix playlist metadata, artist display, add album search and tests

### DIFF
--- a/music_assistant/providers/vk_music/api_client.py
+++ b/music_assistant/providers/vk_music/api_client.py
@@ -189,6 +189,35 @@ class VKMusicClient:
             LOGGER.error("Error fetching playlists: %s", err)
             raise ResourceTemporarilyUnavailable("Failed to fetch playlists") from err
 
+    async def get_playlist_info(self, owner_id: int, playlist_id: int) -> VKPlaylist | None:
+        """Find a specific playlist by owner_id and playlist_id.
+
+        Since VK API lacks a direct get-playlist-by-id endpoint,
+        we search through the owner's playlists to find a match.
+
+        :param owner_id: Playlist owner ID.
+        :param playlist_id: Playlist ID.
+        :return: Playlist object or None if not found.
+        """
+        service = self._ensure_connected()
+        try:
+            offset = 0
+            while True:
+                playlists = await service.get_playlists_by_userid_async(
+                    owner_id, DEFAULT_LIMIT, offset
+                )
+                if not playlists:
+                    break
+                for playlist in playlists:
+                    if playlist.playlist_id == playlist_id:
+                        return playlist
+                offset += DEFAULT_LIMIT
+                if len(playlists) < DEFAULT_LIMIT:
+                    break
+        except VkApiException as err:
+            LOGGER.debug("Error looking up playlist %s_%s: %s", owner_id, playlist_id, err)
+        return None
+
     # Search
 
     async def search_tracks(

--- a/music_assistant/providers/vk_music/parsers.py
+++ b/music_assistant/providers/vk_music/parsers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 from typing import TYPE_CHECKING
 
 from music_assistant_models.enums import ContentType, ImageType, MediaType
@@ -31,13 +30,13 @@ if TYPE_CHECKING:
 def _create_synthetic_artist_id(artist_name: str) -> str:
     """Create a synthetic artist ID from the artist name.
 
-    VK Music doesn't have artist IDs, only names, so we generate
-    a deterministic ID from the name hash.
+    VK Music doesn't have artist IDs, only names, so we use
+    the artist name directly as the ID.
 
     :param artist_name: Artist name string.
-    :return: Synthetic artist ID.
+    :return: Artist name used as synthetic artist ID.
     """
-    return hashlib.md5(artist_name.encode()).hexdigest()[:16]
+    return artist_name
 
 
 def _create_synthetic_artist(provider: VKMusicProvider, artist_name: str) -> ItemMapping:
@@ -60,7 +59,7 @@ def parse_artist(provider: VKMusicProvider, artist_name: str) -> Artist:
     """Create an Artist object from a name string.
 
     VK Music doesn't have artist entities, only name strings in tracks.
-    We create synthetic artists with hash-based IDs.
+    We create synthetic artists using the name as the ID.
 
     :param provider: The VK Music provider instance.
     :param artist_name: Artist name string.
@@ -119,6 +118,24 @@ def parse_track(provider: VKMusicProvider, song: VKSong) -> Track:
     # Parse artist (VK only has single artist string)
     if song.artist:
         track.artists = UniqueList([_create_synthetic_artist(provider, song.artist)])
+
+    # Try to add cover image if available on the song object.
+    # vkpymusic Song (v3.5.1) does not expose album cover data,
+    # but we check for common attributes for forward compatibility.
+    for img_attr in ("photo", "album_cover", "cover_url", "thumb"):
+        img_url = getattr(song, img_attr, None)
+        if img_url and isinstance(img_url, str) and img_url.startswith("http"):
+            track.metadata.images = UniqueList(
+                [
+                    MediaItemImage(
+                        type=ImageType.THUMB,
+                        path=img_url,
+                        provider=provider.instance_id,
+                        remotely_accessible=True,
+                    )
+                ]
+            )
+            break
 
     return track
 

--- a/music_assistant/providers/vk_music/provider.py
+++ b/music_assistant/providers/vk_music/provider.py
@@ -128,6 +128,20 @@ class VKMusicProvider(MusicProvider):
             except ResourceTemporarilyUnavailable as err:
                 self.logger.warning("Playlist search unavailable: %s", err)
 
+            # Also search albums (VK treats albums as playlists)
+            try:
+                existing_ids = {p.item_id for p in result.playlists}
+                albums = await self.client.search_albums(search_query, count=limit)
+                for album in albums[:limit]:
+                    try:
+                        parsed = parse_playlist(self, album)
+                        if parsed.item_id not in existing_ids:
+                            result.playlists = [*result.playlists, parsed]
+                    except InvalidDataError as err:
+                        self.logger.debug("Error parsing album as playlist: %s", err)
+            except ResourceTemporarilyUnavailable as err:
+                self.logger.warning("Album search unavailable: %s", err)
+
         return result
 
     # Get single items
@@ -185,10 +199,14 @@ class VKMusicProvider(MusicProvider):
         playlist_id = int(parts[1])
         access_key = parts[2] if len(parts) > 2 else None
 
-        # VK API doesn't have direct get_playlist - verify it exists by fetching tracks
+        # Try to fetch full playlist metadata from the owner's playlists
+        vk_playlist = await self.client.get_playlist_info(owner_id, playlist_id)
+        if vk_playlist:
+            return parse_playlist(self, vk_playlist)
+
+        # Fallback: verify existence by fetching tracks, return minimal object
         await self.client.get_playlist_tracks(owner_id, playlist_id, access_key, count=1, offset=0)
 
-        # Create minimal playlist object
         return Playlist(
             item_id=prov_playlist_id,
             provider=self.instance_id,

--- a/tests/providers/vk_music/__init__.py
+++ b/tests/providers/vk_music/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for VK Music provider."""

--- a/tests/providers/vk_music/conftest.py
+++ b/tests/providers/vk_music/conftest.py
@@ -1,0 +1,36 @@
+"""Shared fixtures and stubs for VK Music provider tests."""
+
+from __future__ import annotations
+
+import pytest
+from music_assistant_models.enums import MediaType
+from music_assistant_models.media_items import ItemMapping
+
+
+class ProviderStub:
+    """Minimal provider-like object for parser tests (no Mock).
+
+    Provides the minimal interface needed by parse_* functions.
+    """
+
+    domain = "vk_music"
+    instance_id = "vk_music_test_instance"
+
+    def __init__(self) -> None:
+        """Initialize stub with minimal client."""
+        self.client = type("ClientStub", (), {"user_id": 12345})()
+
+    def get_item_mapping(self, media_type: MediaType | str, key: str, name: str) -> ItemMapping:
+        """Return ItemMapping for the given media type, key and name."""
+        return ItemMapping(
+            media_type=MediaType(media_type) if isinstance(media_type, str) else media_type,
+            item_id=key,
+            provider=self.instance_id,
+            name=name,
+        )
+
+
+@pytest.fixture
+def provider_stub() -> ProviderStub:
+    """Return a real provider stub (no Mock)."""
+    return ProviderStub()

--- a/tests/providers/vk_music/test_parsers.py
+++ b/tests/providers/vk_music/test_parsers.py
@@ -1,0 +1,262 @@
+"""Tests for VK Music parsers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from vkpymusic.models import Playlist as VKPlaylist
+from vkpymusic.models import Song as VKSong
+
+from music_assistant.providers.vk_music.parsers import (
+    _create_synthetic_artist,
+    _create_synthetic_artist_id,
+    parse_artist,
+    parse_playlist,
+    parse_track,
+)
+from music_assistant.providers.vk_music.provider import VKMusicProvider
+
+if TYPE_CHECKING:
+    from .conftest import ProviderStub
+
+
+class TestCreateSyntheticArtistId:
+    """Tests for _create_synthetic_artist_id."""
+
+    def test_returns_artist_name_directly(self) -> None:
+        """Test that synthetic artist ID is the artist name itself."""
+        assert _create_synthetic_artist_id("Test Artist") == "Test Artist"
+
+    def test_different_names_produce_different_ids(self) -> None:
+        """Test that different names produce different IDs."""
+        id1 = _create_synthetic_artist_id("Artist One")
+        id2 = _create_synthetic_artist_id("Artist Two")
+        assert id1 != id2
+
+    def test_same_name_produces_same_id(self) -> None:
+        """Test deterministic ID generation."""
+        id1 = _create_synthetic_artist_id("Same Artist")
+        id2 = _create_synthetic_artist_id("Same Artist")
+        assert id1 == id2
+
+    def test_special_characters_preserved(self) -> None:
+        """Test that special characters in names are preserved."""
+        name = "DJ Shadow & Cut Chemist"
+        assert _create_synthetic_artist_id(name) == name
+
+
+class TestCreateSyntheticArtist:
+    """Tests for _create_synthetic_artist."""
+
+    def test_creates_item_mapping(self, provider_stub: ProviderStub) -> None:
+        """Test that a valid ItemMapping is created."""
+        result = _create_synthetic_artist(cast("VKMusicProvider", provider_stub), "Test Artist")
+        assert result.item_id == "Test Artist"
+        assert result.name == "Test Artist"
+        assert result.provider == provider_stub.instance_id
+
+
+class TestParseArtist:
+    """Tests for parse_artist."""
+
+    def test_parse_artist_basic(self, provider_stub: ProviderStub) -> None:
+        """Test parsing a basic artist."""
+        result = parse_artist(cast("VKMusicProvider", provider_stub), "My Artist")
+        assert result.item_id == "My Artist"
+        assert result.name == "My Artist"
+        assert result.provider == provider_stub.instance_id
+        assert len(result.provider_mappings) == 1
+        mapping = next(iter(result.provider_mappings))
+        assert mapping.item_id == "My Artist"
+        assert mapping.provider_domain == "vk_music"
+        assert mapping.provider_instance == provider_stub.instance_id
+
+
+class TestParseTrack:
+    """Tests for parse_track."""
+
+    def test_parse_track_basic(self, provider_stub: ProviderStub) -> None:
+        """Test parsing a basic track."""
+        song = VKSong(
+            title="Test Song",
+            artist="Test Artist",
+            duration=240,
+            track_id="456",
+            owner_id="123",
+            url="https://example.com/audio.mp3",
+        )
+        result = parse_track(cast("VKMusicProvider", provider_stub), song)
+        assert result.item_id == "123_456"
+        assert result.name == "Test Song"
+        assert result.duration == 240
+        assert result.provider == provider_stub.instance_id
+        assert len(result.provider_mappings) == 1
+        mapping = next(iter(result.provider_mappings))
+        assert mapping.item_id == "123_456"
+
+    def test_parse_track_with_artist(self, provider_stub: ProviderStub) -> None:
+        """Test parsing a track populates artist."""
+        song = VKSong(
+            title="Song",
+            artist="Singer",
+            duration=180,
+            track_id="1",
+            owner_id="2",
+            url="",
+        )
+        result = parse_track(cast("VKMusicProvider", provider_stub), song)
+        assert len(result.artists) == 1
+        assert result.artists[0].name == "Singer"
+
+    def test_parse_track_no_artist(self, provider_stub: ProviderStub) -> None:
+        """Test parsing a track with empty artist."""
+        song = VKSong(
+            title="Song",
+            artist="",
+            duration=180,
+            track_id="1",
+            owner_id="2",
+            url="",
+        )
+        result = parse_track(cast("VKMusicProvider", provider_stub), song)
+        assert len(result.artists) == 0
+
+    def test_parse_track_version_extraction(self, provider_stub: ProviderStub) -> None:
+        """Test that version is extracted from title."""
+        song = VKSong(
+            title="Song Name (Acoustic Version)",
+            artist="Artist",
+            duration=200,
+            track_id="1",
+            owner_id="2",
+            url="",
+        )
+        result = parse_track(cast("VKMusicProvider", provider_stub), song)
+        assert result.name == "Song Name"
+        assert result.version == "Acoustic Version"
+
+    def test_parse_track_unknown_title(self, provider_stub: ProviderStub) -> None:
+        """Test parsing a track with empty title defaults to Unknown Track."""
+        song = VKSong(
+            title="",
+            artist="Artist",
+            duration=180,
+            track_id="1",
+            owner_id="2",
+            url="",
+        )
+        result = parse_track(cast("VKMusicProvider", provider_stub), song)
+        assert result.name == "Unknown Track"
+
+    def test_parse_track_zero_duration(self, provider_stub: ProviderStub) -> None:
+        """Test parsing a track with zero duration."""
+        song = VKSong(
+            title="Song",
+            artist="Artist",
+            duration=0,
+            track_id="1",
+            owner_id="2",
+            url="",
+        )
+        result = parse_track(cast("VKMusicProvider", provider_stub), song)
+        assert result.duration == 0
+
+
+class TestParsePlaylist:
+    """Tests for parse_playlist."""
+
+    def test_parse_playlist_basic(self, provider_stub: ProviderStub) -> None:
+        """Test parsing a basic playlist."""
+        playlist = VKPlaylist(
+            title="My Playlist",
+            description="A nice playlist",
+            photo="https://example.com/photo.jpg",
+            count=10,
+            followers=5,
+            owner_id=12345,
+            playlist_id=999,
+            access_key="abc123",
+        )
+        result = parse_playlist(cast("VKMusicProvider", provider_stub), playlist)
+        assert result.item_id == "12345_999_abc123"
+        assert result.name == "My Playlist"
+        assert result.owner == "Me"
+        assert result.is_editable is False
+        assert result.metadata.description == "A nice playlist"
+
+    def test_parse_playlist_other_owner(self, provider_stub: ProviderStub) -> None:
+        """Test parsing playlist from another user."""
+        playlist = VKPlaylist(
+            title="Their Playlist",
+            description="",
+            photo="",
+            count=5,
+            followers=0,
+            owner_id=99999,
+            playlist_id=1,
+            access_key="key",
+        )
+        result = parse_playlist(cast("VKMusicProvider", provider_stub), playlist)
+        assert result.owner == "VK Music"
+
+    def test_parse_playlist_with_cover(self, provider_stub: ProviderStub) -> None:
+        """Test parsing playlist with cover image."""
+        playlist = VKPlaylist(
+            title="Playlist",
+            description="",
+            photo="https://example.com/cover.jpg",
+            count=10,
+            followers=0,
+            owner_id=12345,
+            playlist_id=1,
+            access_key="",
+        )
+        result = parse_playlist(cast("VKMusicProvider", provider_stub), playlist)
+        assert result.metadata.images is not None
+        assert len(result.metadata.images) == 1
+        assert result.metadata.images[0].path == "https://example.com/cover.jpg"
+
+    def test_parse_playlist_no_cover(self, provider_stub: ProviderStub) -> None:
+        """Test parsing playlist without cover image."""
+        playlist = VKPlaylist(
+            title="Playlist",
+            description="",
+            photo="",
+            count=10,
+            followers=0,
+            owner_id=12345,
+            playlist_id=1,
+            access_key="",
+        )
+        result = parse_playlist(cast("VKMusicProvider", provider_stub), playlist)
+        assert result.metadata.images is None or len(result.metadata.images) == 0
+
+    def test_parse_playlist_no_access_key(self, provider_stub: ProviderStub) -> None:
+        """Test playlist ID format without access key."""
+        playlist = VKPlaylist(
+            title="Playlist",
+            description="",
+            photo="",
+            count=10,
+            followers=0,
+            owner_id=12345,
+            playlist_id=1,
+            access_key="",
+        )
+        result = parse_playlist(cast("VKMusicProvider", provider_stub), playlist)
+        assert result.item_id == "12345_1"
+
+    def test_parse_playlist_unknown_title(self, provider_stub: ProviderStub) -> None:
+        """Test parsing playlist with empty title."""
+        playlist = VKPlaylist(
+            title="",
+            description="",
+            photo="",
+            count=0,
+            followers=0,
+            owner_id=12345,
+            playlist_id=1,
+            access_key="",
+        )
+        result = parse_playlist(cast("VKMusicProvider", provider_stub), playlist)
+        assert result.name == "Unknown Playlist"


### PR DESCRIPTION
## Summary
- **Fix get_artist() hash display**: Artist names were showing as MD5 hashes in the UI. Now uses the artist name directly as the synthetic ID.
- **Fix get_playlist() stub data**: `get_playlist()` was returning generic "Playlist 123" instead of real metadata. Added `get_playlist_info()` to fetch actual title/description/cover from VK API.
- **Add album search**: VK album search results (which are playlists in VK) are now included in search results with deduplication.
- **Forward-compatible track cover art**: Added safe `getattr` checks for image attributes on Song objects for future vkpymusic versions.
- **Unit tests**: Added 18 parser tests covering artist ID generation, track parsing, and playlist parsing.

## Test plan
- [x] All 18 new unit tests pass (`pytest tests/providers/vk_music/ -v`)
- [x] Full test suite passes (373/373, 0 regressions)
- [x] Pre-commit hooks pass (ruff, mypy, formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)