### PR TITLE
feat(yandex_music): update provider to v2.2.2

### DIFF
--- a/music_assistant/providers/yandex_music/streaming.py
+++ b/music_assistant/providers/yandex_music/streaming.py
@@ -165,7 +165,7 @@ class YandexMusicStreamingManager:
         """Select the best quality download info based on user preference.
 
         :param download_infos: List of DownloadInfo objects.
-        :param preferred_quality: User's quality preference (efficient/balanced/superb).
+        :param preferred_quality: User's quality preference (efficient/high/balanced/superb).
         :return: Best matching DownloadInfo or None.
         """
         if not download_infos:
@@ -272,7 +272,7 @@ class YandexMusicStreamingManager:
         if codec_lower in ("aac-mp4", "he-aac-mp4"):
             return ContentType.MP4, ContentType.AAC
 
-        # Plain formats: container and codec are the same
+        # Plain single-codec formats: codec is implied by content_type, no separate codec_type
         if codec_lower == "flac":
             return ContentType.FLAC, ContentType.UNKNOWN
         if codec_lower in ("mp3", "mpeg"):

--- a/tests/providers/yandex_music/test_streaming.py
+++ b/tests/providers/yandex_music/test_streaming.py
@@ -70,10 +70,10 @@ def test_select_best_quality_lossless_returns_flac(
     assert result.direct_link == "https://example.com/track.flac"
 
 
-def test_select_best_quality_balanced_returns_medium_bitrate(
+def test_select_best_quality_balanced_falls_back_to_highest(
     streaming_manager: YandexMusicStreamingManager,
 ) -> None:
-    """When preferred is 'balanced' and no option in range, fallback to highest bitrate."""
+    """When preferred is 'balanced' and no option in 128-256kbps range, highest bitrate is used."""
     mp3 = _make_download_info("mp3", 320, "https://example.com/track.mp3")
     flac = _make_download_info("flac", 0, "https://example.com/track.flac")
     download_infos = [mp3, flac]


### PR DESCRIPTION
## Auto-sync from provider repo

**Source**: [ma-provider-yandex-music v2.2.2](https://github.com/trudenboy/ma-provider-yandex-music/releases/tag/v2.2.2)

---
After merging, `rebuild-integration.yml` will auto-rebuild the integration branch.