### PR TITLE
feat(yandex_music): update provider to v2.2.7

### DIFF
--- a/tests/providers/yandex_music/test_streaming.py
+++ b/tests/providers/yandex_music/test_streaming.py
@@ -48,7 +48,7 @@ def streaming_manager(
     streaming_provider_stub: StreamingProviderStub,
 ) -> YandexMusicStreamingManager:
     """Create streaming manager with real stub (no Mock)."""
-    return YandexMusicStreamingManager(streaming_provider_stub)
+    return YandexMusicStreamingManager(streaming_provider_stub)  # type: ignore[arg-type]
 
 
 @pytest.fixture
@@ -56,7 +56,7 @@ def streaming_manager_with_tracking(
     streaming_provider_stub_with_tracking: StreamingProviderStubWithTracking,
 ) -> YandexMusicStreamingManager:
     """Create streaming manager with tracking logger for assertions."""
-    return YandexMusicStreamingManager(streaming_provider_stub_with_tracking)
+    return YandexMusicStreamingManager(streaming_provider_stub_with_tracking)  # type: ignore[arg-type]
 
 
 def test_select_best_quality_lossless_returns_flac(


### PR DESCRIPTION
## Auto-sync from provider repo

**Source**: [ma-provider-yandex-music v2.2.7](https://github.com/trudenboy/ma-provider-yandex-music/releases/tag/v2.2.7)

---
After merging, `rebuild-integration.yml` will auto-rebuild the integration branch.