### PR TITLE
feat(yandex_music): update provider to v2.5.3

### DIFF
--- a/music_assistant/providers/yandex_music/api_client.py
+++ b/music_assistant/providers/yandex_music/api_client.py
@@ -904,6 +904,17 @@ class YandexMusicClient:
         """
         return await self._get_landing_waves("mixes-waves")
 
+    async def get_waves_landing(self) -> list[dict[str, Any]] | None:
+        """Get featured wave stations from /landing-blocks/waves endpoint.
+
+        Returns Yandex-curated wave categories with station items — the "Волны"
+        landing page content, separate from the full rotor/stations/list and from
+        the AI mixes-waves sets.
+
+        :return: List of wave category dicts, or None on error.
+        """
+        return await self._get_landing_waves("waves")
+
     async def _get_landing_waves(self, block: str) -> list[dict[str, Any]] | None:
         """Fetch wave categories from a /landing-blocks/<block> endpoint.
 
@@ -933,7 +944,7 @@ class YandexMusicClient:
     ) -> list[tuple[str, str, str, str | None]]:
         """Get available rotor wave stations grouped by category.
 
-        Calls rotor_stations_list() — the underlying endpoint for landing-blocks/waves.
+        Calls rotor_stations_list() — equivalent to the rotor/stations/list API endpoint.
         Filters out personal stations (type 'user') since My Wave is handled separately.
 
         :param language: Language for station names (e.g. 'ru', 'en'). Defaults to API default.

--- a/music_assistant/providers/yandex_music/constants.py
+++ b/music_assistant/providers/yandex_music/constants.py
@@ -143,6 +143,7 @@ BROWSE_NAMES_RU: Final[dict[str, str]] = {
     "radio": "Радио",
     "my_waves": "Персональные",
     "my_waves_set": "AI Сеты",
+    "waves_landing": "Избранные волны",
     "genre": "Жанры",
     "epoch": "Эпоха",
     "local": "Местное",
@@ -214,6 +215,7 @@ BROWSE_NAMES_EN: Final[dict[str, str]] = {
     "radio": "Radio",
     "my_waves": "Personal",
     "my_waves_set": "AI Wave Sets",
+    "waves_landing": "Featured Waves",
     "genre": "Genres",
     "epoch": "Era",
     "local": "Local",
@@ -325,6 +327,9 @@ MY_WAVES_FOLDER_ID: Final[str] = "my_waves"
 
 # AI Wave Sets subfolder (from /landing-blocks/mixes-waves)
 MY_WAVES_SET_FOLDER_ID: Final[str] = "my_waves_set"
+
+# Featured Waves subfolder inside Radio (from /landing-blocks/waves)
+WAVES_LANDING_FOLDER_ID: Final[str] = "waves_landing"
 
 # Top-level browse group folders
 FOR_YOU_FOLDER_ID: Final[str] = "for_you"

--- a/music_assistant/providers/yandex_music/provider.py
+++ b/music_assistant/providers/yandex_music/provider.py
@@ -71,6 +71,7 @@ from .constants import (
     TRACK_BATCH_SIZE,
     WAVE_CATEGORY_DISPLAY_ORDER,
     WAVES_FOLDER_ID,
+    WAVES_LANDING_FOLDER_ID,
 )
 from .parsers import (
     _get_image_url as get_image_url,
@@ -245,6 +246,10 @@ class YandexMusicProvider(MusicProvider):
         if subpath == MY_WAVES_SET_FOLDER_ID:
             return await self._browse_vibe_sets(path, path_parts)
 
+        # Handle waves_landing/ path (Featured Waves from /landing-blocks/waves)
+        if subpath == WAVES_LANDING_FOLDER_ID:
+            return await self._browse_waves_landing(path, path_parts)
+
         # Handle direct tag subpath (when folder is played by URI, the full path
         # "picks/category/tag" is lost and only the tag slug arrives as subpath).
         # Skip the API call for standard top-level folders that are never tag slugs.
@@ -258,6 +263,7 @@ class YandexMusicProvider(MusicProvider):
             RADIO_FOLDER_ID,
             MY_WAVES_FOLDER_ID,
             MY_WAVES_SET_FOLDER_ID,
+            WAVES_LANDING_FOLDER_ID,
             FOR_YOU_FOLDER_ID,
             COLLECTION_FOLDER_ID,
         }
@@ -864,6 +870,18 @@ class YandexMusicProvider(MusicProvider):
                         is_playable=False,
                     )
                 )
+            # Featured Waves — only show if landing-blocks/waves returns data
+            waves_landing = await self._get_waves_landing_cached()
+            if waves_landing:
+                folders.append(
+                    BrowseFolder(
+                        item_id=WAVES_LANDING_FOLDER_ID,
+                        provider=self.instance_id,
+                        path=f"{base}{WAVES_LANDING_FOLDER_ID}",
+                        name=names.get(WAVES_LANDING_FOLDER_ID, "Featured Waves"),
+                        is_playable=False,
+                    )
+                )
             for cat in WAVE_CATEGORY_DISPLAY_ORDER:
                 if cat in categorized:
                     folders.append(
@@ -1102,6 +1120,28 @@ class YandexMusicProvider(MusicProvider):
         :return: List of mix category dicts from the API, or None on error.
         """
         return await self.client.get_mixes_waves()
+
+    @use_cache(3600)
+    async def _get_waves_landing_cached(self) -> list[dict[str, Any]] | None:
+        """Get Featured Waves data from /landing-blocks/waves, cached for 1 hour.
+
+        :return: List of wave category dicts from the API, or None on error.
+        """
+        return await self.client.get_waves_landing()
+
+    async def _browse_waves_landing(
+        self, path: str, path_parts: list[str]
+    ) -> Sequence[MediaItemType | ItemMapping | BrowseFolder]:
+        """Browse Featured Waves (from /landing-blocks/waves).
+
+        :param path: Full browse path.
+        :param path_parts: Split path parts after ://.
+        :return: List of folders or tracks.
+        """
+        waves_data = await self._get_waves_landing_cached()
+        return await self._browse_wave_categories(
+            path, path_parts, waves_data or [], WAVES_LANDING_FOLDER_ID
+        )
 
     async def _browse_wave_categories(
         self,


### PR DESCRIPTION
## Auto-sync from provider repo

**Source**: [ma-provider-yandex-music v2.5.3](https://github.com/trudenboy/ma-provider-yandex-music/releases/tag/v2.5.3)

---
After merging, `rebuild-integration.yml` will auto-rebuild the integration branch.